### PR TITLE
Added debounce.

### DIFF
--- a/packages/app/src/App.js
+++ b/packages/app/src/App.js
@@ -99,7 +99,7 @@ const App = props => {
           </ListHeader>
         )}
         <div>
-          {values.error && <Message>Oops an error occured.</Message>}
+          {values.error && <Message>Oops an error occurred.</Message>}
           {!values.error && !values.results.items.length && !values.loading && (
             <Message>
               No repos yet, trying searching for one like 'testing'

--- a/packages/app/src/components/Search.js
+++ b/packages/app/src/components/Search.js
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import PropTypes from "prop-types";
 import styled from "@emotion/styled";
 /** @jsx jsx */
@@ -18,30 +18,53 @@ const Input = styled.input`
   }
 `;
 
-const Button = styled.button`
-  padding: 16px 32px;
-  font-size: 16px;
-  border: 1px solid #2cb1bc;
-  background-color: #2cb1bc;
-  color: #044e54;
-  font-weight: 600;
-`;
+// Hook
+function useDebounce(value, delay) {
+  // State and setters for debounced value
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(
+    () => {
+      // Update debounced value after delay
+      const handler = setTimeout(() => {
+        setDebouncedValue(value);
+      }, delay);
+
+      // Cancel the timeout if value changes (also on delay change or unmount)
+      // This is how we prevent debounced value from updating if value is changed ...
+      // .. within the delay period. Timeout gets cleared and restarted.
+      return () => {
+        clearTimeout(handler);
+      };
+    },
+    [value, delay] // Only re-call effect if value or delay changes
+  );
+
+  return debouncedValue;
+}
 
 const Search = props => {
-  const onClick = async () => {
-    props.onClick(search);
-    window.scrollTo(0, 0);
-  };
-
-  const onKeyDown = e => {
-    if (e.key === "Enter") {
-      onClick();
-    }
-  };
-
   const onChange = e => setSearch(e.target.value);
 
   const [search, setSearch] = useState("");
+
+  const debounceSearchTerm = useDebounce(search, 500);
+
+  const onClick = async term => {
+    props.onClick(term);
+    window.scrollTo(0, 0);
+  };
+
+  useEffect(
+    () => {
+      if (debounceSearchTerm) {
+        onClick(debounceSearchTerm);
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [debounceSearchTerm] // Only call effect if debounced search term changes
+  );
+
   return (
     <div
       css={css`
@@ -54,10 +77,8 @@ const Search = props => {
       <Input
         placeholder="Search for repos"
         value={search}
-        onKeyDown={onKeyDown}
         onChange={onChange}
       />
-      <Button onClick={onClick}>Search</Button>
     </div>
   );
 };


### PR DESCRIPTION
Added debounce. The reason there were issues was eslint was forcing props as a dependency on the `useEffect` which was causing an infinite loop.  So as expected telling eslint to ignore the deps fixed the infinite loop